### PR TITLE
Optimize autocrafter with timestamp-based slot caching

### DIFF
--- a/EpicHoppers-Plugin/src/main/java/com/craftaro/epichoppers/hopper/levels/modules/ModuleAutoCrafting.java
+++ b/EpicHoppers-Plugin/src/main/java/com/craftaro/epichoppers/hopper/levels/modules/ModuleAutoCrafting.java
@@ -37,7 +37,31 @@ public class ModuleAutoCrafting extends Module {
     private static final Map<Hopper, ItemStack> CACHED_CRAFTING = new ConcurrentHashMap<>();
     private static final ItemStack NO_CRAFT = new ItemStack(Material.AIR);
 
+    // Cache for last output slot to optimize stacking (lag-free with timestamp)
+    // Key: Hopper, Value: {slot index, material type, timestamp}
+    private static final Map<Hopper, LastOutputSlot> LAST_OUTPUT_SLOT = new ConcurrentHashMap<>();
+    private static final long OUTPUT_SLOT_CACHE_TTL = 60000; // 60 seconds timeout
+
     private final boolean crafterEjection;
+
+    // Helper class to cache last output slot with timestamp
+    private static class LastOutputSlot {
+        final int slot;
+        final Material material;
+        final long timestamp;
+
+        LastOutputSlot(int slot, Material material) {
+            this.slot = slot;
+            this.material = material;
+            this.timestamp = System.currentTimeMillis();
+        }
+
+        boolean isValid(Material currentMaterial) {
+            // Cache is valid if material matches and not too old
+            return this.material == currentMaterial &&
+                   (System.currentTimeMillis() - this.timestamp) < OUTPUT_SLOT_CACHE_TTL;
+        }
+    }
 
     public ModuleAutoCrafting(SongodaPlugin plugin, GuiManager guiManager) {
         super(plugin, guiManager);
@@ -158,6 +182,7 @@ public class ModuleAutoCrafting extends Module {
                 }
 
                 if (freeSlotAfterRemovingIngredients) {
+                    // Remove ingredients
                     for (Map.Entry<Integer, Integer> entry : slotsToAlter.entrySet()) {
                         if (entry.getValue() <= 0) {
                             items[entry.getKey()] = null;
@@ -167,18 +192,53 @@ public class ModuleAutoCrafting extends Module {
                     }
 
                     // Add the resulting item into the inventory - Just making sure there actually is enough space
-                    for (int i = 0; i < items.length; i++) {
-                        if (items[i] == null ||
-                                (items[i].isSimilar(recipe.result)
-                                        && items[i].getAmount() + recipe.result.getAmount() <= items[i].getMaxStackSize())) {
-                            if (items[i] == null) {
-                                items[i] = recipe.result.clone();
-                            } else {
-                                items[i].setAmount(items[i].getAmount() + recipe.result.getAmount());
-                            }
+                    boolean outputAdded = false;
+                    int outputSlot = -1;
 
-                            break;
+                    // OPTIMIZATION: Check cached slot first (lag-free with timestamp)
+                    LastOutputSlot cachedSlot = LAST_OUTPUT_SLOT.get(hopper);
+                    if (cachedSlot != null && cachedSlot.isValid(recipe.result.getType())) {
+                        int i = cachedSlot.slot;
+                        if (i < items.length && items[i] != null &&
+                            items[i].isSimilar(recipe.result) &&
+                            items[i].getAmount() + recipe.result.getAmount() <= items[i].getMaxStackSize()) {
+                            // Cached slot is still valid! Use it directly (no iteration needed)
+                            items[i].setAmount(items[i].getAmount() + recipe.result.getAmount());
+                            outputAdded = true;
+                            outputSlot = i;
                         }
+                    }
+
+                    // If cached slot didn't work, do normal search
+                    if (!outputAdded) {
+                        // First pass: Look for existing stacks of the same item
+                        for (int i = 0; i < items.length; i++) {
+                            if (items[i] != null &&
+                                items[i].isSimilar(recipe.result) &&
+                                items[i].getAmount() + recipe.result.getAmount() <= items[i].getMaxStackSize()) {
+                                items[i].setAmount(items[i].getAmount() + recipe.result.getAmount());
+                                outputAdded = true;
+                                outputSlot = i;
+                                break;
+                            }
+                        }
+
+                        // Second pass: Look for empty slots
+                        if (!outputAdded) {
+                            for (int i = 0; i < items.length; i++) {
+                                if (items[i] == null) {
+                                    items[i] = recipe.result.clone();
+                                    outputAdded = true;
+                                    outputSlot = i;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    // Update cache with the slot we used
+                    if (outputAdded && outputSlot >= 0) {
+                        LAST_OUTPUT_SLOT.put(hopper, new LastOutputSlot(outputSlot, recipe.result.getType()));
                     }
 
                     hopperCache.setContents(items);


### PR DESCRIPTION
## Summary

This PR optimizes the autocrafter module by adding timestamp-based caching to remember the last output slot used. This prevents inventory fragmentation and improves performance.

## Problem

The autocrafter was iterating through all inventory slots on every single craft operation to find where to place the output item. This had two issues:

1. **Performance**: O(n) iteration on every craft, even when crafting the same item repeatedly
2. **Inventory fragmentation**: Same item type scattered across multiple slots (e.g., diamond blocks appearing in slots 0, 1, and 4 instead of stacking together)

## Solution

Implemented a slot caching mechanism with timestamp-based validation:

- **Cache structure**: Map<Hopper, LastOutputSlot> storing slot index, material type, and timestamp
- **TTL**: 60-second timeout to handle material changes or slot reorganization
- **Fast path**: O(1) cached slot check before falling back to iteration
- **Two-pass fallback**: First searches for existing stacks of same type, then for empty slots

## Technical Details

The caching logic:
1. Check if we have a cached slot for this hopper and material (timestamp < 60s)
2. If valid and slot still has space → use it directly (no iteration!)
3. If invalid → two-pass search:
   - First pass: find existing stacks of same item to merge with
   - Second pass: find empty slots
4. Update cache with whichever slot was used

## Benefits

- **Performance**: Eliminates repeated iteration for consecutive crafts of same item
- **Clean inventory**: Items stack properly in same slot instead of fragmenting
- **Backwards compatible**: Falls back gracefully when cache invalid

## Testing

Tested with 10,000 diamonds being auto-crafted into diamond blocks:
- ✅ All blocks stack in same slot until full
- ✅ No performance degradation with continuous crafting
- ✅ Cache properly invalidates after 60s or material change