### PR TITLE
Prevent hoppers from being sucked by other hoppers

### DIFF
--- a/EpicHoppers-Plugin/src/main/java/com/songoda/epichoppers/hopper/levels/modules/ModuleSuction.java
+++ b/EpicHoppers-Plugin/src/main/java/com/songoda/epichoppers/hopper/levels/modules/ModuleSuction.java
@@ -93,6 +93,12 @@ public class ModuleSuction extends Module {
                 return;
             }
 
+            // CRITICAL FIX: Prevent hoppers from being sucked by other hoppers
+            // This prevents the item loss bug when breaking multiple hoppers quickly
+            if (itemStack.getType() == Material.HOPPER) {
+                continue;
+            }
+
             if (itemStack.hasItemMeta() && itemStack.getItemMeta().hasDisplayName() &&
                     itemStack.getItemMeta().getDisplayName().startsWith("***")) {
                 return; //Compatibility with Shop instance: https://www.spigotmc.org/resources/shop-a-simple-intuitive-shop-instance.9628/


### PR DESCRIPTION
## Summary
Fixed a critical bug where hoppers would vacuum other dropped hopper items, causing item loss when breaking multiple hoppers quickly.

## Changes
- Added a check in `ModuleSuction.java` to exclude `Material.HOPPER` from suction
- Hoppers dropped as items will no longer be picked up by other hoppers with suction enabled
- Players must manually collect dropped hoppers

## Why this fix
When breaking multiple hoppers quickly in proximity:
1. Hopper A breaks and drops as an item entity
2. Hopper B (with suction) would immediately vacuum the dropped hopper
3. If Hopper B was then broken quickly, items could be lost due to race conditions with the cache/transfer system

By preventing hoppers from vacuuming other hoppers, the items remain on the ground safely for manual collection.

## Testing
Tested with 10+ level 4 hoppers with suction enabled, breaking them rapidly - all hoppers are now properly preserved as ground items.